### PR TITLE
Fix. Pick between cursor and defined position when it is zero.

### DIFF
--- a/lib/binary-file.js
+++ b/lib/binary-file.js
@@ -70,7 +70,7 @@ class BinaryFile {
   read (length, position) {
     return new Promise((resolve) => {
       const buffer = new Buffer(length);
-      fsRead(this.fd, buffer, 0, buffer.length, position || this.cursor).then((bytesRead) => {
+      fsRead(this.fd, buffer, 0, buffer.length, position === undefined ? this.cursor : position).then((bytesRead) => {
         if (typeof position === 'undefined') this.cursor += bytesRead;
         resolve(buffer);
       });
@@ -140,7 +140,7 @@ class BinaryFile {
 
   write (buffer, position) {
     return new Promise((resolve) => {
-      fsWrite(this.fd, buffer, 0, buffer.length, position || this.cursor).then((bytesWritten) => {
+      fsWrite(this.fd, buffer, 0, buffer.length, position === undefined ? this.cursor : position).then((bytesWritten) => {
         if (typeof position === 'undefined') this.cursor += bytesWritten;
         resolve(bytesWritten);
       });


### PR DESCRIPTION
Hello, when defining the position as zero it is defaulting to the cursor position because of the OR comparator, this PR contains a quick fix for that by specifically checking if the position is undefined or not.

Thank you.